### PR TITLE
chore: replace backdoor with node

### DIFF
--- a/local-console/src/local_console/core/camera.py
+++ b/local-console/src/local_console/core/camera.py
@@ -36,7 +36,7 @@ class Camera:
     information that the Camera Firmware reports.
     """
 
-    EA_STATE_TOPIC = "state/backdoor-EA_Main/placeholder"
+    EA_STATE_TOPIC = "state/node/placeholder"
     SYSINFO_TOPIC = "systemInfo"
     DEPLOY_STATUS_TOPIC = "deploymentStatus"
 

--- a/local-console/src/local_console/core/camera/mixin_mqtt.py
+++ b/local-console/src/local_console/core/camera/mixin_mqtt.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 
 # MQTT constants
-EA_STATE_TOPIC = "state/backdoor-EA_Main/placeholder"
+EA_STATE_TOPIC = "state/node/placeholder"
 SYSINFO_TOPIC = "systemInfo"
 DEPLOY_STATUS_TOPIC = "deploymentStatus"
 CONNECTION_STATUS_TIMEOUT = timedelta(seconds=180)

--- a/local-console/src/local_console/core/camera/mixin_streaming.py
+++ b/local-console/src/local_console/core/camera/mixin_streaming.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 
 
 # MQTT constants
-EA_STATE_TOPIC = "state/backdoor-EA_Main/placeholder"
+EA_STATE_TOPIC = "state/node/placeholder"
 SYSINFO_TOPIC = "systemInfo"
 DEPLOY_STATUS_TOPIC = "deploymentStatus"
 CONNECTION_STATUS_TIMEOUT = timedelta(seconds=180)
@@ -114,14 +114,14 @@ class StreamingMixin(HasMQTTset, IsAsyncReady):
     async def streaming_rpc_stop(self) -> None:
         assert self.mqtt_client
 
-        instance_id = "backdoor-EA_Main"
+        instance_id = "node"
         method = "StopUploadInferenceData"
         await self.mqtt_client.rpc(instance_id, method, "{}")
 
     async def streaming_rpc_start(self, roi: Optional[UnitROI] = None) -> None:
         assert self.mqtt_client
 
-        instance_id = "backdoor-EA_Main"
+        instance_id = "node"
         method = "StartUploadInferenceData"
         host = get_webserver_ip()
         upload_url = f"http://{host}:{self.upload_port}"

--- a/tests/unit/core/test_camera.py
+++ b/tests/unit/core/test_camera.py
@@ -249,7 +249,7 @@ async def test_process_state_topic_correct(
         observer.assert_not_awaited()
 
         backdoor_state = {
-            "state/backdoor-EA_Main/placeholder": b64encode(
+            "state/node/placeholder": b64encode(
                 device_config.model_dump_json().encode("utf-8")
             ).decode("utf-8")
         }
@@ -276,7 +276,7 @@ async def test_process_state_topic_wrong(schema, caplog, cs_init) -> None:
     camera._onwire_schema = schema
     wrong_obj = {"a": "b"}
     backdoor_state = {
-        "state/backdoor-EA_Main/placeholder": b64encode(json.dumps(wrong_obj).encode())
+        "state/node/placeholder": b64encode(json.dumps(wrong_obj).encode())
     }
     await camera._process_state_topic(backdoor_state)
     assert "Error while validating device configuration" in caplog.text

--- a/tests/unit/core/test_camera_mqtt.py
+++ b/tests/unit/core/test_camera_mqtt.py
@@ -71,7 +71,7 @@ async def test_streaming_rpc_stop(cs_init, nursery):
 
         await driver.streaming_rpc_stop()
         mock_rpc.assert_awaited_with(
-            "backdoor-EA_Main", "StopUploadInferenceData", "{}"
+            "node", "StopUploadInferenceData", "{}"
         )
 
 

--- a/tests/unit/gui/test_driver.py
+++ b/tests/unit/gui/test_driver.py
@@ -111,7 +111,7 @@ async def test_streaming_rpc_start(mocked_driver_with_agent, cs_init) -> None:
     ):
         await driver.camera_state.streaming_rpc_start()
         mock_rpc.assert_awaited_with(
-            "backdoor-EA_Main",
+            "node",
             "StartUploadInferenceData",
             StartUploadInferenceData(
                 StorageName=upload_url,


### PR DESCRIPTION
On Raspberry Pi, commands and configuration must go to `node` instead of `backdoor-EA_Main`, and state will come from `node` instead of `backdoor-EA_Main`